### PR TITLE
Iterate-AI added 2 events

### DIFF
--- a/frontend/threaddit/src/pages/profile/Profile.jsx
+++ b/frontend/threaddit/src/pages/profile/Profile.jsx
@@ -1,3 +1,5 @@
+import mixpanel from 'mixpanel-browser';
+import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { AnimatePresence } from 'framer-motion';
@@ -38,10 +40,11 @@ export function Profile() {
     }
   }, [action, data, username, logout]);
 
-  useEffect(() => {
-    document.title = 'u/' + username;
-    return () => (document.title = 'Threaddit');
-  }, [username]);
+useEffect(() => {
+  document.title = 'u/' + username;
+  mixpanel.track('Profile_check', { 'profile_checked': 'True' });
+  return () => (document.title = 'Threaddit');
+}, [username]);
   return (
     <div className="flex flex-col flex-1 items-center w-full bg-theme-cultured">
       {userIsFetching ? (

--- a/frontend/threaddit/src/pages/thread/SubThread.jsx
+++ b/frontend/threaddit/src/pages/thread/SubThread.jsx
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import mixpanel from 'mixpanel-browser';
 import axios from 'axios';
 import { AnimatePresence } from 'framer-motion';
 import { useEffect, useRef, useState } from 'react';
@@ -35,7 +36,8 @@ export function SubThread() {
   const { mutate } = useMutation({
     mutationFn: async (has_subscribed) => {
       if (has_subscribed) {
-        axios.delete(`/api/threads/subscription/${threadData.id}`).then(() =>
+        axios.delete(`/api/threads/subscription/${threadData.id}`).then(() => {
+          mixpanel.track('subscribed', { total_subscribers: threadData?.subscriberCount });
           queryClient.setQueryData(
             { queryKey: ['thread', params.threadName] },
             (oldData) => {
@@ -46,7 +48,8 @@ export function SubThread() {
           )
         );
       } else {
-        axios.post(`/api/threads/subscription/${threadData.id}`).then(() =>
+        axios.post(`/api/threads/subscription/${threadData.id}`).then(() => {
+          mixpanel.track('subscribed', { total_subscribers: threadData?.subscriberCount });
           queryClient.setQueryData(
             { queryKey: ['thread', params.threadName] },
             (oldData) => {


### PR DESCRIPTION

        This PR was created by Iterate to apply changes made in the session.

        Type: ADD
        Target File: frontend/threaddit/src/pages/thread/SubThread.jsx
        Event Name: subscribed
        Attributes: total_subscribers (Numeric)
        Description: This change adds tracking for the event "subscribed" 
        with the following attributes: total_subscribers: total number of subscribers of the thread (e.g., 23)
        
        
        
        This PR was created by Iterate to apply changes made in the session.

        Type: ADD
        Target File: frontend/threaddit/src/pages/profile/Profile.jsx
        Event Name: Profile_check
        Attributes: profile_checked (String)
        Description: This change adds tracking for the event "Profile_check" 
        with the following attributes: profile_checked: N/A (e.g., N/A)
        
        
        